### PR TITLE
Update whitelist.txt

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,5 +1,8 @@
 ! Source name: AdGuard Whitelist
 ! Source: https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212
+! Title: Adguard Whitelist by cedwards4038
+! Description: AdGuard Whitelist derived from pihole commonly whitelisted domains(https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212)
+! Homepage: https://github.com/cedwards4038/adguard-whitelist
 
 !Compiled By Charles Edwards
 
@@ -373,6 +376,7 @@
 @@||wa.me
 @@/REGEX/^whatsapp-cdn-shv-[0-9]{2}-[a-z]{3}[0-9]\.fbcdn\.net$
 @@/REGEX/^((www|(w[0-9]\.)?web|media((-[a-z]{3}|\.[a-z]{4})[0-9]{1,2}-[0-9](\.|-)(cdn|fna))?)\.)?whatsapp\.(com|net)$
+@@/REGE/^((alt)[0-9](-))?mtalk\.google\.com$
 
 @@||www/wa/me
 
@@ -451,3 +455,11 @@
 !really don't like allowing this one, but it's what makes paramount+ work per https://www.reddit.com/r/pihole/comments/lxnjdg/comment/imj4g8m/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button
 @@||pubads.g.doubleclick.net
 @@||pagead2.googlesyndication.com
+
+!OpenAI
+@@||chat.openai.com
+@@||auth.openai.com
+
+!NCAA Live Stream in App
+@@||live-manifests-aka.warnermediacdn.com
+


### PR DESCRIPTION
Added appropriate entries from https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212/206 since October of 2024

1. Fixed Whatsapp push notifications
2. fixed live streams in the NCAA app
3. Fixed ChatGPT (OpenAI)

Also added several lines at the top to properly have this filter named within the Adguard application